### PR TITLE
feat: support tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,15 @@ categories = []
 authors = ["Yoshua Wuyts <rust@yosh.is>"]
 
 [features]
+tokio = ["dep:tokio"]
+async-std = ["dep:async-std"]
 
 [dependencies]
-async-std = { version = "1.10.0", features = ["unstable"] }
+async-std = { version = "1.10.0", features = ["unstable"], optional = true }
 futures-concurrency = "7.5.0"
 pin-project = "1.0.10"
+tokio = { version = "1.40.0", optional = true, features = ["rt"] }
 
 [dev-dependencies]
+async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
+tokio = { version = "1.40.0", features = ["rt", "time", "macros"] }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,42 +3,42 @@ use std::{
     time::Duration,
 };
 
-use async_std::task;
+#[cfg(feature = "async-std")]
+use async_std::task::sleep;
+#[cfg(feature = "tokio")]
+use tokio::time::sleep;
 
 use futures_concurrency::prelude::*;
 use parallel_future::prelude::*;
 
-#[test]
-fn spawn() {
-    async_std::task::block_on(async {
-        let res = async { "nori is a horse" }.par().await;
-        assert_eq!(res, "nori is a horse");
-    })
+#[cfg_attr(feature = "async-std", async_std::test)]
+#[cfg_attr(feature = "tokio", tokio::test)]
+async fn spawn() {
+    let res = async { "nori is a horse" }.par().await;
+    assert_eq!(res, "nori is a horse");
 }
 
-#[test]
-fn with_join() {
-    async_std::task::block_on(async {
-        // A parallel execution of two futures
-        let a = async { 1 }.par();
-        let b = async { 2 }.par();
+#[cfg_attr(feature = "async-std", async_std::test)]
+#[cfg_attr(feature = "tokio", tokio::test)]
+async fn with_join() {
+    // A parallel execution of two futures
+    let a = async { 1 }.par();
+    let b = async { 2 }.par();
 
-        let res: [i32; 2] = (a, b).join().await.into();
-        assert_eq!(res.iter().sum::<i32>(), 3);
-    })
+    let res: [i32; 2] = (a, b).join().await.into();
+    assert_eq!(res.iter().sum::<i32>(), 3);
 }
 
-#[test]
-fn is_lazy() {
-    async_std::task::block_on(async {
-        let polled = Arc::new(Mutex::new(false));
-        let polled_2 = polled.clone();
-        let _res = async move {
-            *polled_2.lock().unwrap() = true;
-        }
-        .par();
+#[cfg_attr(feature = "async-std", async_std::test)]
+#[cfg_attr(feature = "tokio", tokio::test)]
+async fn is_lazy() {
+    let polled = Arc::new(Mutex::new(false));
+    let polled_2 = polled.clone();
+    let _res = async move {
+        *polled_2.lock().unwrap() = true;
+    }
+    .par();
 
-        task::sleep(Duration::from_millis(500)).await;
-        assert_eq!(*polled.lock().unwrap(), false);
-    })
+    sleep(Duration::from_millis(500)).await;
+    assert_eq!(*polled.lock().unwrap(), false);
 }


### PR DESCRIPTION
This PR adds support for Tokio runtime.

I'm not sure if this aligns with the direction of the project or whether that's a good place to implement this change. Please let me know if there's a better way to get `parallel-future` working on Tokio or there's a better way to implement it